### PR TITLE
Accept a function as value generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![stable](http://badges.github.io/stability-badges/dist/stable.svg)](http://github.com/badges/stability-badges)
 
-Creates a new dense array with the given size, optionally filled with a specified value. 
+Creates a new dense array with the given size, optionally filled with a value.
 
 ```js
 var array = require('new-array')
@@ -16,8 +16,9 @@ array(4, 0)
 array()
 // > []
 
-array(2).map((x, i) => i)
-// > [0, 1]
+// using a function to generate values
+array(4, (x, i) => i * 10)
+// > [0, 10, 20, 30]
 ```
 
 Primarily motivated by the fact that `new Array(n)` produces an array of holes that does not play well with methods like `Array#map()`.
@@ -26,9 +27,9 @@ Primarily motivated by the fact that `new Array(n)` produces an array of holes t
 
 [![NPM](https://nodei.co/npm/new-array.png)](https://www.npmjs.com/package/new-array)
 
-#### `arr = newArray(n[, value])`
+#### `arr = newArray(n[, value || fn])`
 
-Returns a new dense array with length `n` (default 0), where each element is set to `value` (or undefined).
+Returns a new dense array with length `n` (default 0), where each element is set to `value`, or `fn(i)` if its a function, or undefined if not specified.
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ array()
 // > []
 
 // using a function to generate values
-array(4, (x, i) => i * 10)
+array(4, (i) => i * 10)
 // > [0, 10, 20, 30]
 ```
 

--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@ module.exports = newArray
 
 function newArray (n, value) {
   n = n || 0
+  var isFn = typeof value === 'function'
   var array = new Array(n)
   for (var i = 0; i < n; i++) {
-    array[i] = value
+    array[i] = isFn ? value(i) : value
   }
   return array
 }

--- a/test.js
+++ b/test.js
@@ -6,8 +6,8 @@ test('create a new array filled with a value, or zero', function(t) {
   t.deepEqual(array(2), [undefined, undefined])
   t.deepEqual(array(2, 0), [0, 0])
   t.deepEqual(array(2, 'foo'), ['foo', 'foo'])
-  t.deepEqual(array(2).map(function() {
-    return 0
-  }), [0, 0])
+  t.deepEqual(array(4, function(i) {
+    return i
+  }), [0, 1, 2, 3])
   t.end()
 })


### PR DESCRIPTION
This PR adds the option to use a function as value generator:

`array(10, (i) => i * 2) // => [0, 2, 4, 8 ... 20]`

The result is the same as create the array and map the values, but **it does not use an intermediary array** (some potencial optimization on large arrays)
